### PR TITLE
fix: remove `not` keyboard; allow only contextually for `not in` / `is not`

### DIFF
--- a/gracile-core/src/lexer.rs
+++ b/gracile-core/src/lexer.rs
@@ -34,7 +34,6 @@ pub enum TokenKind {
     KwInclude,
     KwDebug,
     KwIs,
-    KwNot,
     KwIn,
 
     StringLit(String),
@@ -106,7 +105,6 @@ impl std::fmt::Display for TokenKind {
             TokenKind::KwInclude => "keyword 'include'",
             TokenKind::KwDebug => "keyword 'debug'",
             TokenKind::KwIs => "keyword 'is'",
-            TokenKind::KwNot => "keyword 'not'",
             TokenKind::KwIn => "keyword 'in'",
 
             TokenKind::True => "'true'",
@@ -740,7 +738,6 @@ fn keyword_or_ident(s: String) -> TokenKind {
         "include" => TokenKind::KwInclude,
         "debug" => TokenKind::KwDebug,
         "is" => TokenKind::KwIs,
-        "not" => TokenKind::KwNot,
         "in" => TokenKind::KwIn,
         "true" => TokenKind::True,
         "false" => TokenKind::False,

--- a/gracile-core/src/parser.rs
+++ b/gracile-core/src/parser.rs
@@ -584,7 +584,7 @@ impl Parser {
         let expr = self.parse_membership()?;
         if self.peek_kind() == &TokenKind::KwIs {
             self.advance();
-            let negated = if self.peek_kind() == &TokenKind::KwNot {
+            let negated = if matches!(self.peek_kind(), TokenKind::Ident(n) if n == "not") {
                 self.advance();
                 true
             } else {
@@ -603,28 +603,26 @@ impl Parser {
 
     fn parse_membership(&mut self) -> Result<Expr> {
         let expr = self.parse_additive()?;
-        match self.peek_kind() {
-            TokenKind::KwIn => {
-                self.advance();
-                let collection = self.parse_additive()?;
-                Ok(Expr::Membership {
-                    expr: Box::new(expr),
-                    negated: false,
-                    collection: Box::new(collection),
-                })
-            }
-            TokenKind::KwNot => {
-                self.advance();
-                self.expect_keyword(TokenKind::KwIn)?;
-                let collection = self.parse_additive()?;
-                Ok(Expr::Membership {
-                    expr: Box::new(expr),
-                    negated: true,
-                    collection: Box::new(collection),
-                })
-            }
-            _ => Ok(expr),
+        if self.peek_kind() == &TokenKind::KwIn {
+            self.advance();
+            let collection = self.parse_additive()?;
+            return Ok(Expr::Membership {
+                expr: Box::new(expr),
+                negated: false,
+                collection: Box::new(collection),
+            });
         }
+        if matches!(self.peek_kind(), TokenKind::Ident(n) if n == "not") {
+            self.advance(); // consume "not"
+            self.expect_keyword(TokenKind::KwIn)?;
+            let collection = self.parse_additive()?;
+            return Ok(Expr::Membership {
+                expr: Box::new(expr),
+                negated: true,
+                collection: Box::new(collection),
+            });
+        }
+        Ok(expr)
     }
 
     fn parse_additive(&mut self) -> Result<Expr> {


### PR DESCRIPTION
fixes #3 